### PR TITLE
Add unit test CI

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,37 @@
+name: .NET Build & Unit Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Restore Dependencies
+        run: dotnet restore src
+      - name: Build
+        run: dotnet build src --configuration Release --no-restore
+      - name: Unit Tests
+        run: |
+          cd ./tests/Unit/
+          dotnet test --no-restore -nodereuse:false \
+            /p:UseSharedCompilation=false \
+            /p:UseRazorBuildServer=false \
+            /p:CollectCoverage=true \
+            /p:CoverletOutputFormat=opencover \
+            /p:CoverletOutput=/home/runner/work/Gossip/ \
+      - name: Publish Code Coverage
+        uses: codecov/codecov-action@v2
+        with:
+          files: /home/runner/work/Gossip/coverage.opencover.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## Description

Adds a new action that will run on PRs vs main and merges to main branch. This action will run the full suite of Gossip unit tests to ensure all tests pass, and will fail the build if any do not.

Additionally, this action will save and publish the codecov report from the unit test run, giving us better insight into our unit test coverage.

Closely follows the pattern in place for AeroSharp, [here](https://github.com/wayfair-incubator/AeroSharp/blob/main/.github/workflows/unit.yml).

Tested in my local fork [here](https://github.com/suzicurran/Gossip/pull/1).

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/Gossip/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass