### PR TITLE
CI for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,8 +20,17 @@ jobs:
         run: dotnet restore src
       - name: Build
         run: dotnet build src --configuration Release --no-restore
-      - name: Set up SQL Database & Run Test Script
-        run: docker-compose up
+      - name: Set up SQL Database
+        run: docker-compose up --detach sql-server-db
+      - name: Integration Tests
+        run: |
+          cd ./tests/Integration/
+          dotnet test --no-restore -nodereuse:false \
+            /p:UseSharedCompilation=false \
+            /p:UseRazorBuildServer=false \
+            /p:CollectCoverage=true \
+            /p:CoverletOutputFormat=opencover \
+            /p:CoverletOutput=/home/runner/work/Gossip/ \
       - name: Publish Code Coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,29 @@
+name: .NET Build & Integration Test
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Restore Dependencies
+        run: dotnet restore src
+      - name: Build
+        run: dotnet build src --configuration Release --no-restore
+      - name: Set up SQL Database & Run Test Script
+        run: docker-compose up
+      - name: Publish Code Coverage
+        uses: codecov/codecov-action@v2
+        with:
+          files: /home/runner/work/Gossip/coverage.opencover.xml
+          fail_ci_if_error: true

--- a/tests/Integration/Connections/CommandTimeoutTests.cs
+++ b/tests/Integration/Connections/CommandTimeoutTests.cs
@@ -30,25 +30,11 @@ namespace Gossip.IntegrationTests.Connections
         [Test]
         public async Task When_command_timeout_is_lower_than_the_execution_time_it_should_not_throw_SqlException()
         {
-            var mssqlConnectionStringBuilder = new MsSqlConnectionStringBuilder();
-            var databaseServerAddress = DatabaseSetup.GetDatabaseServerAddress();
-            var connectionString = mssqlConnectionStringBuilder.Build(new ConnectionStringSettings
-            {
-                ApplicationName = "Test",
-                Database = "master",
-                MachineName = "Test",
-                Server = databaseServerAddress,
-                Password = "55Data!Access!Password!",
-                Username = "sa",
-                MaxPoolSize = 50,
-                DefaultCommandTimeout = 5
-            });
-
             var mssql = new MsSql();
 
             var db = Database
                 .Configure(mssql)
-                .WithConnectionString(() => new ConnectionString { Value = connectionString })
+                .WithConnectionString(() => new ConnectionString { Value = DatabaseSetup.LocalMsSqlConnectionString })
                 .WithCommandTimeout(2)
                 .Build();
 


### PR DESCRIPTION
## Description

Adds a new action that will run on PRs vs main and merges to main branch. This action will run the full suite of Gossip integration tests to ensure all tests pass, and will fail the build if any do not.

Additionally, this action will save and publish the codecov report from the unit test run, giving us better insight into our unit test coverage.

I've also removed connection details I found duplicated in the body of a test, after confirming they were identical to the default connection config.

Tested in my local fork [here](https://github.com/suzicurran/Gossip/pull/1).

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/Gossip/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass